### PR TITLE
add CMake option to skip testing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,8 +22,12 @@ if(UNIX)
   target_link_libraries(GKlib m)
 endif(UNIX)
 
-include_directories("test")
-add_subdirectory("test")
+if (GKlib_DISABLE_TESTING)
+  message("GKlib: testing disabled")
+else()
+  include_directories("test")
+  add_subdirectory("test")
+endif()
 
 install(TARGETS GKlib
   ARCHIVE DESTINATION lib/${LINSTALL_PATH}


### PR DESCRIPTION
I'm trying to use GKlib on one of the newer M1 macs with arm processors. When I build GKlib with CMake, the library itself compiles successfully, but the tests fail with the following errors:

```
/Users/sam/code/GKlib/test/gkuniq.c:77:22: error: unrecognized instruction mnemonic
    __asm__ volatile("clflush (%0)\n\t"
                     ^
<inline asm>:1:2: note: instantiated into assembly here
        clflush (x10)
        ^
/Users/sam/code/GKlib/test/gkuniq.c:83:20: error: unrecognized instruction mnemonic
  __asm__ volatile("sfence\n\t"
                   ^
<inline asm>:1:2: note: instantiated into assembly here
        sfence
        ^
```

The explicit assembly instructions are not portable, so the arm processors don't know what to do with them.

This PR adds a way for CMake users to skip building the tests by specifying "-DGKlib_DISABLE_TESTING=TRUE" at configure time. This change is backward-compatible so that if this flag option is omitted, then the tests will still be built.

Regardless of whether or not the tests build successfully, having an option to disable them can be helpful for users that just want to use GKlib without paying the additional cost of building tests they likely won't run.