### PR TITLE
Fix detection of thread-local storage capability for MSVC

### DIFF
--- a/conf/check_thread_storage.c
+++ b/conf/check_thread_storage.c
@@ -1,4 +1,4 @@
-extern __thread int x;
+extern __declspec(thread) int x;
 
 int main(int argc, char **argv) {
   return 0;


### PR DESCRIPTION
This PR fixes an incorrect check for detecting whether for MSVC supports thread-local storage or not.

The build system uses the cmake function `try_compile` to compile a test file which contains `extern __thread int x`, but this code always fails with MSVC since the correct thread-local attribute would be `__declspec(thread)` ([Source from Microsoft](https://learn.microsoft.com/en-us/cpp/parallel/thread-local-storage-tls?view=msvc-170)). The `__thread` keyword is redefined for MSVC in cmake for the library, but this does not affect this call to `try_compile`.
This then leads to the thread-local attribute being omitted for MSVC builds, which in turn leads to crashes when calling into the library from multiple threads at the same time.

I tested this change with the latest MSVC compiler by writing a small test program with calls `METIS_PartGraphRecursive` inside a `std::for_each(std::execution::par, ...)` loop. Without this changes the code crashes even for just two parallel executions, with the change it runs successfully for a larger number of parallel executions.