### PR TITLE
Fix incorrect `GKRAND` macro to match `USE_GKRAND`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,7 +88,7 @@ target_compile_definitions(${PROJECT_NAME}
   PUBLIC $<$<NOT:$<BOOL:${ASSERT}>>:NDEBUG>
          $<$<NOT:$<BOOL:${ASSERT2}>>:NDEBUG2>
          $<$<BOOL:${DEBUG}>:DEBUG>
-         $<$<BOOL:${GKRAND}>:GKRAND>
+         $<$<BOOL:${GKRAND}>:USE_GKRAND>
          $<$<BOOL:${NO_X86}>:NO_X86>
          )
 


### PR DESCRIPTION
This PR fixes a mismatch between the macro defined in the CMake configuration and the macro checked in the code.
The previous CMake logic defined `GKRAND`, but the code uses `#ifdef USE_GKRAND`. This change ensures CMake defines `USE_GKRAND` as intended, so the conditional logic is activated correctly.