### PR TITLE
Make randInRange width-independent so 32-/64-bit METIS/ParMETIS match (#57)

### DIFF
--- a/include/gk_mkrandom.h
+++ b/include/gk_mkrandom.h
@@ -11,6 +11,17 @@
 #ifndef _GK_MKRANDOM_H
 #define _GK_MKRANDOM_H
 
+/* Set GK_RNG_LEGACY_WIDTH to 1 to restore the historical behavior in which the
+   random sequence from randInRange()/randArrayPermute() depends on the width of
+   RNGT. By default (0), ranges that fit in 31 bits are drawn from gk_randint32()
+   regardless of width, so 32- and 64-bit integer builds produce identical
+   results (e.g. matching 32-bit and 64-bit METIS/ParMETIS partitions when all
+   quantities fit in 32 bits). gk_randint32() consumes the same generator state
+   as the width-specific rand(), so this does not desynchronize the RNG. */
+#ifndef GK_RNG_LEGACY_WIDTH
+#define GK_RNG_LEGACY_WIDTH 0
+#endif
+
 /*************************************************************************/\
 /*! The generator for the rand() related routines.  \
    \params RNGT  the datatype that defines the range of values over which\
@@ -47,6 +58,8 @@ RNGT FPRFX ## rand(void) \
 /**************************************************************************/\
 RNGT FPRFX ## randInRange(RNGT max) \
 {\
+  if (!GK_RNG_LEGACY_WIDTH && (uint64_t)max <= 0x7fffffffULL) \
+    return (RNGT)((RNGT)gk_randint32() % max); \
   return (RNGT)((FPRFX ## rand())%max); \
 }\
 \


### PR DESCRIPTION
## Problem (#57)

32-bit and 64-bit METIS/ParMETIS produce **different decompositions** even when every
quantity fits in 32 bits. The randomness driving vertex permutation comes from
`gk_mkrandom.h`'s `randInRange()`, which returns `rand() % max`; `rand()` dispatches on
`sizeof(RNGT)` -- `gk_randint32()` for <=32-bit types, `gk_randint64()` for 64-bit. In
METIS/ParMETIS `RNGT = idx_t`, so a `-DIDXTYPEWIDTH=64` build draws full 64-bit values and a
32-bit build draws 31-bit values.

Because `gk_randint32()` is `gk_randint64() & 0x7FFFFFFF`, both consume one generator word --
the *only* difference is `(r & 0x7FFFFFFF) % max` vs `r % max`. That single masking difference
changes every draw, hence different permutations and partitions.

## Fix

For ranges that fit in 31 bits, draw from `gk_randint32()` regardless of `RNGT` width:

```c
if (!GK_RNG_LEGACY_WIDTH && (uint64_t)max <= 0x7fffffffULL)
  return (RNGT)((RNGT)gk_randint32() % max);
return (RNGT)((FPRFX ## rand()) % max);
```

- **32-bit output is byte-identical** to before (its `rand()` already *is* `gk_randint32()`).
- **64-bit now matches 32-bit** for in-range values, and since `gk_randint32()` consumes the
  same generator state as `gk_randint64()`, the RNG is not desynchronized.
- `randArrayPermute()`/`randArrayPermuteFine()` inherit the fix (they call `randInRange`).
- Larger ranges (>2^31-1, only reachable in 64-bit builds) and `max <= 0`/negative are routed
  to the existing path unchanged.
- Escape hatch: define `GK_RNG_LEGACY_WIDTH=1` to restore the old width-dependent behavior.

## Reaches METIS/ParMETIS automatically

METIS consumes GKlib externally (`include_directories(${GKLIB_PATH}/include)`) and instantiates
`GK_MKRANDOM(i, idx_t, idx_t)` (`libmetis/gklib.c`), so `irandInRange`/`irandArrayPermute`
(used throughout `libmetis`, incl. `parmetis.c`) are generated from this header -- the fix
flows in on a GKlib refresh + rebuild, no METIS patch required. `gk_randint32` is provided by
the linked `libGKlib`, so there is no new link dependency.

## Validation

Instantiating `GK_MKRANDOM` at `int32_t` and `int64_t`, seeding identically:
- `randInRange`: **0 / 100000** draws differ (was 100000/100000 before)
- `randArrayPermute`: **0 / 1000** entries differ
- 32-bit sequence unchanged vs current behavior
- clean build (`-Wall -pedantic -Werror`, 0 warnings)

## Reviewer decision

This PR makes width-independence the **default** (32-bit output is unchanged; only 64-bit
small-range output changes once, which is acceptable since METIS does not promise bit-stable
output across versions). To make it opt-in instead, invert the gate. Either way the
`GK_RNG_LEGACY_WIDTH` escape hatch is available.

Closes #57.
