### PR TITLE
Build gkuniq portably using x86 cache-flush intrinsics (#37)

### DIFF
--- a/apps/gkuniq.c
+++ b/apps/gkuniq.c
@@ -8,6 +8,22 @@
 
 #include <GKlib.h>
 
+/* mem_flush() evicts an array from the cache between timed runs using the x86
+   clflush/sfence instructions. These are exposed as the _mm_clflush/_mm_sfence
+   intrinsics on every x86 compiler (GCC, Clang, MSVC, ICC), so we use those
+   rather than GNU-specific inline asm. The intrinsics are x86-only, so the
+   routine is enabled only when an x86 target is detected (and NO_X86 is not
+   set); on other architectures mem_flush() compiles to a no-op. */
+#if (defined(__x86_64__) || defined(_M_X64) || \
+     defined(__i386__)   || defined(_M_IX86)) && !defined(NO_X86)
+  #define GK_HAVE_X86_FLUSH 1
+  #if defined(_MSC_VER)
+    #include <intrin.h>
+  #else
+    #include <immintrin.h>
+  #endif
+#endif
+
 /*************************************************************************/
 /*! Data structures for the code */
 /*************************************************************************/
@@ -66,25 +82,21 @@ void mem_flush(const void *p, unsigned int allocation_size);
 /**************************************************************************/
 void mem_flush(const void *p, unsigned int allocation_size)
 {
-#ifndef NO_X86 
+#ifdef GK_HAVE_X86_FLUSH
   const size_t cache_line = 64;
   const char *cp = (const char *)p;
-  size_t i = 0;
+  size_t i;
 
-  if (p == NULL || allocation_size <= 0)
+  if (p == NULL || allocation_size == 0)
     return;
 
-  for (i = 0; i < allocation_size; i += cache_line) {
-    __asm__ volatile("clflush (%0)\n\t"
-                 :
-                 : "r"(&cp[i])
-                 : "memory");
-  }
+  for (i = 0; i < allocation_size; i += cache_line)
+    _mm_clflush(&cp[i]);
 
-  __asm__ volatile("sfence\n\t"
-                :
-                :
-                : "memory");
+  _mm_sfence();
+#else
+  (void)p;
+  (void)allocation_size;
 #endif
 }
 


### PR DESCRIPTION
## Problem (#37)

`gkuniq` fails to build on MSVC (VS2022):

```
gkuniq.c: error C2065: '__asm__': undeclared identifier
gkuniq.c: error C2143: syntax error: missing ';' before 'volatile'
```

`mem_flush()` (a benchmark helper that evicts an array from cache between timed
runs) used GNU-style `__asm__ volatile("clflush"/"sfence")`, guarded only by
`#ifndef NO_X86`. MSVC does not understand `__asm__`, so a **default** MSVC build
(without `-DNO_X86=ON`) does not compile.

## Fix (portable intrinsics)

Replace the GNU inline asm with the `_mm_clflush` / `_mm_sfence` intrinsics,
which **every x86 compiler exposes** (GCC, Clang, MSVC, ICC). This removes the
inline asm entirely -- one code path for all x86 compilers instead of a
per-compiler `#if`.

The intrinsics are x86-only, so the routine is gated on a compile-time x86
detection rather than relying on the user to pass `NO_X86`:

```c
#if (defined(__x86_64__) || defined(_M_X64) ||
     defined(__i386__)   || defined(_M_IX86)) && !defined(NO_X86)
  #define GK_HAVE_X86_FLUSH 1
  #if defined(_MSC_VER)
    #include <intrin.h>
  #else
    #include <immintrin.h>
  #endif
#endif
```

- On x86 (any compiler): `_mm_clflush()` in the loop + a trailing `_mm_sfence()`.
- On non-x86 targets: `mem_flush()` compiles to a no-op automatically (no longer
  depends on `NO_X86` being set by the Makefile/user).
- The existing `NO_X86` override is still honored as a manual off-switch.

## Validation

- `-DNO_X86=ON` build: `gkuniq` compiles and links, 0 warnings/errors.
- arm64 default build (no `NO_X86`): `GK_HAVE_X86_FLUSH` is correctly undefined,
  the no-op path is taken, and it compiles clean under `-Wall -Wextra -Werror`
  (the `(void)` casts avoid unused-parameter warnings).
- x86_64 preprocessing selects the `<immintrin.h>` + `_mm_clflush`/`_mm_sfence`
  branch.

I could not run a real MSVC compile in this environment, so the Windows build
should be confirmed by a reviewer with MSVC. `_mm_clflush`/`_mm_sfence` are the
standard intrinsics for these instructions (SSE2, the x86-64 baseline) and are
provided by `<intrin.h>` on MSVC.

Closes #37.
